### PR TITLE
Respond to server kill command.

### DIFF
--- a/dnscat2.ps1
+++ b/dnscat2.ps1
@@ -252,6 +252,7 @@ dnscat2: Powershell Version
       {
         $AcknowledgementNumber = AcknowledgeData $ReturningData $AcknowledgementNumber
         WriteOutput $ReturningData
+        if ($ReturningData -like "*killed: *") { exit }
       }
     }
   }


### PR DESCRIPTION
Current code doesn't respond to "Session Killed: REASON" command from server, causing the server to get stuck in a loop with the following message being thrown back to the screen:

Session X killed (again): No reason given

This basically renders the server unusable. The fix simply kills powershell if it receives a session killed command.
